### PR TITLE
OSS and elasticsearch 7.0.0 support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - *Add support for elastic 7 and oss versions and molecule scenario test* @adrian-arapiles
 ### Changed
-- _Expose variable **elasticsearch_build_name** for override version to install._
+- _Expose variable **elasticsearch_build_name** for override version to install._ @adrian-arapiles
 
 ## [1.0.0](https://github.com/idealista/elasticsearch_role/tree/1.0.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/elasticsearch_role/tree/develop)
 
+## [1.1.0](https://github.com/idealista/elasticsearch_role/tree/1.1.0)
+### Added
+- *Add support for elastic 7 and oss versions and molecule scenario test* @adrian-arapiles
+### Changed
+- _Expose variable **elasticsearch_build_name** for override version to install._
+
 ## [1.0.0](https://github.com/idealista/elasticsearch_role/tree/1.0.0)
 ### Added
 - *First release* @acuervof

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 ## Getting Started
 
-**THIS ROLE IS FOR 6.x**
+**THIS ROLE IS FOR 6.x or 7.x**
 
-Ansible role for 6.x Elasticsearch. Currently this works on Debian based linux systems. Tested platforms are:
+Ansible role for 6.x/7.x Elasticsearch. Currently this works on Debian based linux systems. Tested platforms are:
 
 * Debian 8
 * Debian 9
@@ -48,7 +48,7 @@ Create or add to your roles dependency file (e.g requirements.yml):
 ```yml
 - src: http://github.com/idealista/elasticsearch_role.git
   scm: git
-  version: 1.0.0
+  version: 1.1.0
   name: elasticsearch
 ```
 
@@ -61,7 +61,6 @@ ansible-galaxy install -p roles -r requirements.yml -f
 Use in a playbook:
 
 ```yml
----
 - hosts: someserver
   roles:
     - role: elasticsearch
@@ -76,7 +75,8 @@ The use of a map ensures the Ansible playbook does not need to be updated to ref
 
 In addition to the elasticsearch_config map, several other parameters are supported for additional functions e.g. script installation. These can be found in the role's defaults/main.yml file.
 
-The following illustrates applying configuration parameters to an Elasticsearch instance.
+## Elastic 6.x
+The following illustrates applying configuration parameters to an Elasticsearch 6.x instance.
 
 ```yaml
 - name: Elasticsearch with custom configuration
@@ -172,6 +172,125 @@ An example of a three server deployment is shown below. The three servers work a
       cluster.name: idealista-cluster
       discovery.zen.ping.unicast.hosts: ["node1", "node2", "node3"]
       discovery.zen.minimum_master_nodes: 2
+      network.host: _site_
+      http.port: 9200
+      transport.tcp.port: 9300
+      node.master: true
+      node.data: true
+      bootstrap.memory_lock: true
+    elasticsearch_api_host: node3
+    elasticsearch_api_port: 9200
+    elasticsearch_plugins:
+      - plugin: ingest-geoip
+```
+## Elastic 7.x
+The following illustrates applying configuration parameters to an Elasticsearch oss (**open source without x-pack**) 
+7.x instance with single-node (development).
+
+```yaml
+- name: Elasticsearch with custom configuration
+  hosts: localhost
+  roles:
+    - role: idealista.elasticsearch_role
+  vars:
+    elasticsearch_version: 7.0.0
+    elasticsearch_build_name: "elasticsearch-oss-{{ elasticsearch_version }}-linux-x86_64"
+    elasticsearch_data_dir: /var/lib/elasticsearch
+    elasticsearch_log_dir: /var/log/elasticsearch
+    elasticsearch_config:
+      node.name: node1
+      discovery.type: single-node
+      node.data: true
+      node.master: true
+      bootstrap.memory_lock: true
+    elasticsearch_heap_size: 1g
+    elasticsearch_api_host: localhost
+    elasticsearch_api_port: 9200
+    elasticsearch_plugins:
+      - plugin: ingest-geoip
+```
+
+See https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html for further details on available options.
+
+
+#### Important Note
+
+**The role uses elasticsearch_api_host and elasticsearch_api_port to communicate with the node for actions only achievable via http e.g. to install templates and to check the NODE IS ACTIVE.  These default to "localhost" and 9200 respectively.  
+If the node is deployed to bind on either a different host or port, these must be changed.**
+
+
+### Multi Node Server Installations
+
+The application of the elasticsearch role results in the installation of a node on a host. Specifying the role multiple times for a host therefore results in the installation of multiple nodes for the host. 
+
+An example of a three server deployment is shown below. The three servers work as master and data nodes.
+
+
+```yaml
+  hosts: node1
+  roles:
+    - role: idealista.elasticsearch_role
+  vars:
+    elasticsearch_version: 7.0.0
+    elasticsearch_build_name: "elasticsearch-oss-{{ elasticsearch_version }}-linux-x86_64"
+    elasticsearch_data_dir: /var/lib/elasticsearch
+    elasticsearch_log_dir: /var/log/elasticsearch
+    elasticsearch_config:
+      node.name: node1
+      cluster.name: idealista-cluster
+      discovery.zen.ping.unicast.hosts: ["node1", "node2", "node3"]
+      #Deprecated on 7.x discovery.zen.minimum_master_nodes: 2
+      cluster.initial_master_nodes: ["node1", "node2", "node3"]
+      network.host: _site_
+      http.port: 9200
+      transport.tcp.port: 9300
+      node.master: true
+      node.data: true
+      bootstrap.memory_lock: true
+    elasticsearch_api_host: node1
+    elasticsearch_api_port: 9200
+    elasticsearch_plugins:
+      - plugin: ingest-geoip
+
+- hosts: node2
+  roles:
+    - role: idealista.elasticsearch_role
+  vars:
+    elasticsearch_version: 7.0.0
+    elasticsearch_build_name: "elasticsearch-oss-{{ elasticsearch_version }}-linux-x86_64"
+    elasticsearch_data_dir: /var/lib/elasticsearch
+    elasticsearch_log_dir: /var/log/elasticsearch
+    elasticsearch_config:
+      node.name: node2
+      cluster.name: idealista-cluster
+      discovery.zen.ping.unicast.hosts: ["node1", "node2", "node3"]
+      #Deprecated on 7.x discovery.zen.minimum_master_nodes: 2
+      cluster.initial_master_nodes: ["node1", "node2", "node3"]
+      network.host: _site_
+      http.port: 9200
+      transport.tcp.port: 9300
+      node.master: true
+      node.data: true
+      bootstrap.memory_lock: true
+    elasticsearch_api_host: node2
+    elasticsearch_api_port: 9200
+    elasticsearch_plugins:
+      - plugin: ingest-geoip
+    
+- hosts: node3
+  roles:
+    - role: idealista.elasticsearch_role
+  vars:
+    elasticsearch_version: 7.0.0
+    elasticsearch_build_name: "elasticsearch-oss-{{ elasticsearch_version }}-linux-x86_64"
+    elasticsearch_data_dir: /var/lib/elasticsearch
+    elasticsearch_log_dir: /var/log/elasticsearch
+    elasticsearch_config:
+      node.name: node3
+      cluster.name: idealista-cluster
+      discovery.zen.ping.unicast.hosts: ["node1", "node2", "node3"]
+      #Deprecated on 7.x discovery.zen.minimum_master_nodes: 2
+      cluster.initial_master_nodes: ["node1", "node2", "node3"]
       network.host: _site_
       http.port: 9200
       transport.tcp.port: 9300

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ## General
-elasticsearch_version: 6.7.0
+elasticsearch_version: 6.7.1
 elasticsearch_force_reinstall: false
 
 # Owner

--- a/molecule/build-name-override/Dockerfile.j2
+++ b/molecule/build-name-override/Dockerfile.j2
@@ -1,0 +1,9 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y iproute sudo systemd systemd-sysv && apt-get clean; fi

--- a/molecule/build-name-override/INSTALL.rst
+++ b/molecule/build-name-override/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Install
+*******
+
+Requirements
+============
+
+* Docker Engine
+* docker-py
+
+Install
+=======
+
+.. code-block:: bash
+
+  $ sudo pip install docker-py

--- a/molecule/build-name-override/create.yml
+++ b/molecule/build-name-override/create.yml
@@ -1,0 +1,70 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Create Dockerfiles from image names
+      template:
+        src: "{{ molecule_scenario_directory }}/Dockerfile.j2"
+        dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      register: platforms
+
+    - name: Discover local Docker images
+      docker_image_facts:
+        name: "molecule_local/{{ item.item.name }}"
+      with_items: "{{ platforms.results }}"
+      register: docker_images
+
+    - name: Build an Ansible compatible image
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        name: "molecule_local/{{ item.item.image }}"
+        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force: "{{ item.item.force | default(true) }}"
+      with_items: "{{ platforms.results }}"
+      when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+
+    - name: Create docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+
+    - name: Create molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.name }}"
+        image: "molecule_local/{{ item.image }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
+        exposed_ports: "{{ item.exposed_ports | default(omit) }}"
+        published_ports: "{{ item.published_ports | default(omit) }}"
+        ulimits: "{{ item.ulimits | default(omit) }}"
+        networks: "{{ item.networks | default(omit) }}"
+        dns_servers: "{{ item.dns_servers | default(omit) }}"
+        pull: false
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"

--- a/molecule/build-name-override/destroy.yml
+++ b/molecule/build-name-override/destroy.yml
@@ -1,0 +1,33 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) deletion to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"
+
+    - name: Delete docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"

--- a/molecule/build-name-override/group_vars/elasticsearch.yml
+++ b/molecule/build-name-override/group_vars/elasticsearch.yml
@@ -1,0 +1,23 @@
+---
+
+elasticsearch_api_port: 9200
+elasticsearch_tcp_port: 9300
+
+elasticsearch_config:
+  node.name: "{{ elasticsearch_api_host }}"
+  cluster.name: idealista-cluster
+  network.host: _site_
+  discovery.seed_hosts: ["esmasterdata1", "esmasterdata2", "esmasterdata3"]
+  cluster.initial_master_nodes: ["esmasterdata1", "esmasterdata2", "esmasterdata3"]
+  http.port: "{{ elasticsearch_api_port }}"
+  transport.tcp.port: "{{ elasticsearch_tcp_port }}"
+  bootstrap.memory_lock: true
+  node.data: true
+  node.master: true
+  node.ingest: false
+  cluster.remote.connect: false
+  http.cors.enabled: true
+  http.cors.allow-origin: "*"
+
+elasticsearch_version: 7.0.0
+elasticsearch_build_name: "elasticsearch-oss-{{ elasticsearch_version }}-linux-x86_64"

--- a/molecule/build-name-override/molecule.yml
+++ b/molecule/build-name-override/molecule.yml
@@ -1,0 +1,76 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: esmasterdata1
+    hostname: esmasterdata1
+    image: idealista/jdk:8u181-stretch-openjdk-headless
+    privileged: true
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+    groups:
+      - elasticsearch
+      - master_data_nodes
+    command: '/lib/systemd/systemd'
+    networks:
+      - name: es-network
+        aliases:
+          - esmasterdata1
+    published_ports:
+      - 9201:9200
+      - 9301:9300
+
+  - name: esmasterdata2
+    hostname: esmasterdata2
+    image: idealista/jdk:8u181-stretch-openjdk-headless
+    privileged: true
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+    groups:
+      - elasticsearch
+      - master_data_nodes
+    command: '/lib/systemd/systemd'
+    networks:
+      - name: es-network
+        aliases:
+          - esmasterdata2
+    published_ports:
+      - 9202:9200
+      - 9302:9300
+
+  - name: esmasterdata3
+    hostname: esmasterdata3
+    image: idealista/jdk:8u181-stretch-openjdk-headless
+    privileged: true
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+    groups:
+      - elasticsearch
+      - master_data_nodes
+    command: '/lib/systemd/systemd'
+    networks:
+      - name: es-network
+        aliases:
+          - esmasterdata3
+    published_ports:
+      - 9203:9200
+      - 9303:9300
+
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: build-name-override
+verifier:
+  name: goss
+  lint:
+    name: yamllint

--- a/molecule/build-name-override/playbook.yml
+++ b/molecule/build-name-override/playbook.yml
@@ -1,0 +1,20 @@
+---
+
+- hosts: esmasterdata1
+  roles:
+    - role: elasticsearch_role
+      vars:
+        elasticsearch_api_host: esmasterdata1
+
+- hosts: esmasterdata2
+  roles:
+    - role: elasticsearch_role
+      vars:
+        elasticsearch_api_host: esmasterdata2
+
+- hosts: esmasterdata3
+  roles:
+    - role: elasticsearch_role
+      vars:
+        elasticsearch_api_host: esmasterdata3
+

--- a/molecule/build-name-override/prepare.yml
+++ b/molecule/build-name-override/prepare.yml
@@ -1,0 +1,12 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks: 
+  - name: Limits on mmap counts
+    sysctl:
+      name: vm.max_map_count
+      value: 262144
+      sysctl_set: true
+      state: present
+      reload: true

--- a/molecule/build-name-override/tests/test_default.yml
+++ b/molecule/build-name-override/tests/test_default.yml
@@ -1,0 +1,22 @@
+---
+
+group:
+  {{ elasticsearch_group }}:
+    exists: true
+
+user:
+  {{ elasticsearch_user }}:
+    exists: true
+    groups:
+      - {{ elasticsearch_group }}
+
+port:
+  tcp:{{ elasticsearch_api_port }}:
+    listening: true
+  tcp:{{ elasticsearch_tcp_port }}:
+    listening: true
+    
+service:
+  elasticsearch:
+    enabled: true
+    running: true

--- a/molecule/build-name-override/verify.yml
+++ b/molecule/build-name-override/verify.yml
@@ -1,0 +1,60 @@
+---
+# This is an example playbook to execute goss tests.
+# Tests need distributed to the appropriate ansible host/groups
+# prior to execution by `goss validate`.
+#
+# The goss ansible module is installed with molecule.  The ANSIBLE_LIBRARY
+# path is updated appropriately on `molecule verify`.
+
+# Details about ansible module:
+#  - https://github.com/indusbox/goss-ansible
+
+- name: Verify
+  hosts: elasticsearch
+  vars:
+    goss_version: v0.3.6
+    goss_arch: amd64
+    goss_dst: /usr/local/bin/goss
+    goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
+    goss_test_directory: /tmp
+    goss_format: documentation
+
+  vars_files:
+    - ../../defaults/main.yml
+    - ../../vars/main.yml
+    - ./group_vars/elasticsearch.yml
+
+  tasks:
+    - name: Download and install goss
+      get_url:
+        url: "{{ goss_url }}"
+        dest: "{{ goss_dst }}"
+        mode: 0755
+
+    - name: Copy tests to remote
+      template:
+        src: "{{ item }}"
+        dest: "{{ goss_test_directory }}/{{ item | basename }}"
+      with_fileglob:
+        - "{{ playbook_dir }}/tests/test_*.yml"
+
+    - name: Register test files
+      shell: "ls {{ goss_test_directory }}/test_*.yml"
+      register: test_files
+
+    - name: Execute Goss tests
+      command: "goss -g {{ item }} validate --format {{ goss_format }}"
+      register: test_results
+      with_items: "{{ test_files.stdout_lines }}"
+      ignore_errors: true
+
+    - name: Display details about the goss results
+      debug:
+        msg: "{{ item.stdout_lines }}"
+      with_items: "{{ test_results.results }}"
+
+    - name: Fail when tests fail
+      fail:
+        msg: "Goss failed to validate"
+      when: item.rc != 0
+      with_items: "{{ test_results.results }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -60,6 +60,11 @@
       elasticsearch_version_check is failed or
       elasticsearch_version_check.json.version.number != elasticsearch_version
 
+- name: Elasticsearch | Define elasticsearch_build_name
+  set_fact:
+    elasticsearch_build_name: "{{ __elasticsearch_build_name }}"
+  when: elasticsearch_build_name is not defined
+
 - name: Elasticsearch | Untar Elasticsearch
   unarchive:
     extra_opts: ['--strip-components=1']

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 elasticsearch_required_libs:
   - unzip
 
-elasticsearch_build_name: "elasticsearch-{{ elasticsearch_version }}"
+__elasticsearch_build_name: "elasticsearch-{{ elasticsearch_version }}"
 elasticsearch_package: "{{ elasticsearch_build_name }}.tar.gz"
 elasticsearch_package_url: "https://artifacts.elastic.co/downloads/elasticsearch/{{ elasticsearch_package }}"
 


### PR DESCRIPTION
- Add possibility to override elasticsearch_build_name for version 7 or oss(open source) version.
- Add molecule scenario test for 7 oss version.

### Description of the Change

Expose var of role **elasticsearch_build_name** for build oss or 7.0.0 build name. 
For default, elasticsearch_build_name will take the previous value.
Add molecule scenario test for oss 7.0.0 version of elastic search.

### Benefits

Customize version to install, for example oss or 7.

### Possible Drawbacks

I'm not sure if any drawback is possible.

### Applicable Issues
 I don't know.
