### PR TITLE
Feature/issue19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/elasticsearch_role/tree/develop)
 
+### Added
+- *[#19](https://github.com/idealista/elasticsearch_role/issues/19) Add daemon_reload: yes to elasticsearch restart handler* @adrian-arapiles
+- *Add optional drop-in template for configure elasticsearch service* @adrian-arapiles
+
 ## [1.5.0](https://github.com/idealista/elasticsearch_role/tree/1.5.0)
 [Full Changelog](https://github.com/idealista/elasticsearch_role/compare/1.4.0...1.5.0)
 ### Added

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,9 @@ elasticsearch_service_enabled: true
 # Current state: started, stopped
 elasticsearch_service_state: started
 
+# If want to apply any extra config to elasticsearch.service
+# elasticsearch_service_dropin_template: "{{ playbook_dir }}/templates/elasticsearch/service.conf"
+
 # Files & Paths
 elasticsearch_home: /opt/elasticsearch
 elasticsearch_conf_dir: "{{ elasticsearch_home }}/config"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,5 +4,5 @@
   systemd:
     name: elasticsearch
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   when: elasticsearch_service_state != 'stopped'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,5 @@
   systemd:
     name: elasticsearch
     state: restarted
+    daemon_reload: yes
   when: elasticsearch_service_state != 'stopped'

--- a/molecule/default/group_vars/elasticsearch.yml
+++ b/molecule/default/group_vars/elasticsearch.yml
@@ -3,6 +3,8 @@ elasticsearch_version: 7.5.2
 elasticsearch_license_type: oss
 elasticsearch_api_port: 9200
 
+elasticsearch_service_dropin_template: "{{ playbook_dir }}/templates/elasticsearch/service.conf"
+
 elasticsearch_config:
   node.name: "{{ elasticsearch_api_host }}"
   cluster.name: idealista-cluster

--- a/molecule/default/templates/elasticsearch/service.conf
+++ b/molecule/default/templates/elasticsearch/service.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,6 +12,23 @@
     - "{{ elasticsearch_pid_dir }}"
     - "{{ elasticsearch_data_dir }}"
 
+- name: Create and config drop-in service config
+  block:
+    - name: Create elasticsearch drop-in service config
+      file:
+        path: /etc/systemd/system/elasticsearch.service.d
+        owner: "{{ elasticsearch_user }}"
+        group: "{{ elasticsearch_group }}"
+        state: directory
+
+    - name: Add drop-in file config to elastic service
+      template:
+        src: "{{ elasticsearch_service_dropin_template }}"
+        dest: /etc/systemd/system/elasticsearch.service.d/{{ elasticsearch_service_dropin_template | basename }}
+        owner: "{{ elasticsearch_user }}"
+        group: "{{ elasticsearch_group }}"
+  when: elasticsearch_service_dropin_template is defined
+
 - name: Elasticsearch | Configuring Elasticsearch
   template:
     src: "{{ item.src }}"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
- [#19] Add daemon_reload: yes to elasticsearch restart handler
- Add optional drop-in template for configure elasticsearch service
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits
You could now override any config of service with drop-in file.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Any. If not set, it works as before.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
[#19]
<!-- Enter any applicable Issues here -->
