### PR TITLE
#22 Avoid double restart when upgrading or service was stopped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
   - pipenv sync
 script:
   - pipenv run molecule test
-  - pipenv run molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/elasticsearch_role/tree/develop)
 
+### Added
+- *[#22](https://github.com/idealista/elasticsearch_role/issues/19) Avoid double restart when upgrading or service was stopped* @adrian-arapiles
+
+### Fixed
+- *Fixed typo double run test on travis.yml* @adrian-arapiles
+
 ## [1.6.0](https://github.com/idealista/elasticsearch_role/tree/1.6.0)
 [Full Changelog](https://github.com/idealista/elasticsearch_role/compare/1.5.0...1.6.0)
 ### Added

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,4 +5,4 @@
     name: elasticsearch
     state: restarted
     daemon_reload: true
-  when: elasticsearch_service_state != 'stopped'
+  when: elasticsearch_service_state != 'stopped' and elasticsearch_service_output.changed == False

--- a/molecule/default/group_vars/elasticsearch.yml
+++ b/molecule/default/group_vars/elasticsearch.yml
@@ -20,7 +20,7 @@ elasticsearch_config:
   http.cors.enabled: true
   http.cors.allow-origin: "*"
 
-elasticsearch_heap_size: "1g"
+elasticsearch_heap_size: "256m"
 elasticsearch_os_tuning: true
 elasticsearch_sysctl_params:
   - name: vm.max_map_count

--- a/molecule/default/group_vars/elasticsearch.yml
+++ b/molecule/default/group_vars/elasticsearch.yml
@@ -20,7 +20,7 @@ elasticsearch_config:
   http.cors.enabled: true
   http.cors.allow-origin: "*"
 
-elasticsearch_heap_size: "256m"
+elasticsearch_heap_size: "1g"
 elasticsearch_os_tuning: true
 elasticsearch_sysctl_params:
   - name: vm.max_map_count

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,11 +1,12 @@
 ---
 
-- name: Elasticsearch | Starting service
+- name: Elasticsearch | Configure service
   systemd:
     name: elasticsearch
     state: "{{ elasticsearch_service_state }}"
     enabled: "{{ elasticsearch_service_enabled }}"
     daemon_reload: true
+  register: elasticsearch_service_output
 
 - name: Elasticsearch | Force handlers
   meta: flush_handlers


### PR DESCRIPTION
### Description of the Change
- #22 Avoid double restart when upgrading or service was stopped
- Fixed typo double run test on travis.yml
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

Now when upgrade the service restart only 1 time, avoiding crash when try to restart second time.

### Possible Drawbacks

I think none, but maybe if I forgot any other condition that I didn't check. I would appreciate any suggestion.

### Applicable Issues

#22 
