### PR TITLE
#43 Set owner permissions on elasticsearch_data_dir on deb install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,20 @@ install:
 env:
   jobs:
     - MOLECULE_DISTRO=idealista/jdk:11.0.6-stretch-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-    - MOLECULE_DISTRO=idealista/jdk:11.0.8-buster-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+    - MOLECULE_DISTRO=idealista/jdk:11.0.12-buster-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 jobs:
   include:
-    - env: MOLECULE_DISTRO=idealista/jdk:8u265-stretch-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - env: MOLECULE_DISTRO=idealista/jdk:8u302-stretch-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-8-openjdk-amd64
       script: pipenv run molecule test -s default
-    - env: MOLECULE_DISTRO=idealista/jdk:8u265-stretch-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - env: MOLECULE_DISTRO=idealista/jdk:8u302-stretch-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-8-openjdk-amd64
       script: pipenv run molecule test -s debian
-    - env: MOLECULE_DISTRO=idealista/jdk:8u265-stretch-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - env: MOLECULE_DISTRO=idealista/jdk:8u302-stretch-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-8-openjdk-amd64
       script: pipenv run molecule test -s oss
-    - env: MOLECULE_DISTRO=idealista/jdk:8u265-buster-adoptopenjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+    - env: MOLECULE_DISTRO=idealista/jdk:8u292-buster-adoptopenjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
       script: pipenv run molecule test -s default
-    - env: MOLECULE_DISTRO=idealista/jdk:8u265-buster-adoptopenjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+    - env: MOLECULE_DISTRO=idealista/jdk:8u292-buster-adoptopenjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
       script: pipenv run molecule test -s debian
-    - env: MOLECULE_DISTRO=idealista/jdk:8u265-buster-adoptopenjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+    - env: MOLECULE_DISTRO=idealista/jdk:8u292-buster-adoptopenjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
       script: pipenv run molecule test -s oss
 script:
   - pipenv run molecule test --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/elasticsearch_role/tree/develop)
+### Fixed
+- *[43](https://github.com/idealista/elasticsearch_role/issues/43) Change owner of `elasticsearch_data_dir` on deb installation* @adrian-arapiles
 
 ## [2.0.0](https://github.com/idealista/elasticsearch_role/tree/2.0.0)
 [Full Changelog](https://github.com/idealista/elasticsearch_role/compare/1.7.1...2.0.0)

--- a/tasks/deb/config.yml
+++ b/tasks/deb/config.yml
@@ -2,11 +2,16 @@
 
 - name: Elasticsearch | Ensure Elasticsearch dirs exist
   file:
-    path: "{{ elasticsearch_log_dir }}"
+    path: "{{ item }}"
     state: directory
     owner: "{{ elasticsearch_user }}"
     group: "{{ elasticsearch_group }}"
     mode: 0755
+  loop:
+    - "{{ elasticsearch_conf_dir }}"
+    - "{{ elasticsearch_log_dir }}"
+    - "{{ elasticsearch_pid_dir }}"
+    - "{{ elasticsearch_data_dir }}"
 
 - name: Create and config drop-in service config
   block:


### PR DESCRIPTION
### Description of the Change
When elasticsearch service start, if any of paths aren't owned by elasticsearch, service will fail.
We ensure to owner data, pid and log path before init elastisearch service.
### Benefits
You can use role without add custom task to ensure paths as owned by elasticsearch user.

### Possible Drawbacks
As I know nothing.
### Applicable Issues
#43 

