### PR TITLE
#46 Be able to use custom uid and gid on elasticsearch user and group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/elasticsearch_role/tree/develop)
 ### Added 
-*[46](https://github.com/idealista/elasticsearch_role/issues/43) Be able to use custom uid and gid on elasticsearch user and group* @adrian-arapiles
+*[46](https://github.com/idealista/elasticsearch_role/issues/46) Be able to use custom uid and gid on elasticsearch user and group* @adrian-arapiles
 
 ## [2.0.1](https://github.com/idealista/elasticsearch_role/tree/2.0.1)
 [Full Changelog](https://github.com/idealista/elasticsearch_role/compare/2.0.0...2.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/elasticsearch_role/tree/develop)
+### Added 
+*[46](https://github.com/idealista/elasticsearch_role/issues/43) Be able to use custom uid and gid on elasticsearch user and group* @adrian-arapiles
 
 ## [2.0.1](https://github.com/idealista/elasticsearch_role/tree/2.0.1)
 [Full Changelog](https://github.com/idealista/elasticsearch_role/compare/2.0.0...2.0.1)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,8 @@ elasticsearch_config: {}
 # Owner
 elasticsearch_user: elasticsearch
 elasticsearch_group: elasticsearch
+# elasticsearch_uid: 990
+# elasticsearch_gid: 990
 
 ## Service
 # Start on boot

--- a/molecule/debian/group_vars/elasticsearch.yml
+++ b/molecule/debian/group_vars/elasticsearch.yml
@@ -4,6 +4,9 @@ elasticsearch_api_port: 9200
 
 elasticsearch_service_dropin_template: "{{ playbook_dir }}/templates/elasticsearch/service.conf"
 
+elasticsearch_uid: 990
+elasticsearch_gid: 990
+
 elasticsearch_config:
   node.name: "{{ elasticsearch_api_host }}"
   cluster.name: idealista-cluster

--- a/molecule/debian/tests/test_default.yml
+++ b/molecule/debian/tests/test_default.yml
@@ -10,13 +10,11 @@ user:
     exists: true
     groups:
       - {{ elasticsearch_group }}
-    uid:
-      lt: 1000
+    uid: 990
 group:
   {{ elasticsearch_group }}:
     exists: true
-    gid:
-      lt: 1000
+    gid: 990
 
 port:
   tcp:{{ elasticsearch_api_port }}:

--- a/molecule/default/group_vars/elasticsearch.yml
+++ b/molecule/default/group_vars/elasticsearch.yml
@@ -4,6 +4,9 @@ install_mode: tar
 
 elasticsearch_service_dropin_template: "{{ playbook_dir }}/templates/elasticsearch/service.conf"
 
+elasticsearch_uid: 990
+elasticsearch_gid: 990
+
 elasticsearch_config:
   node.name: "{{ elasticsearch_api_host }}"
   cluster.name: idealista-cluster

--- a/molecule/default/tests/test_default.yml
+++ b/molecule/default/tests/test_default.yml
@@ -10,13 +10,11 @@ user:
       exists: true
       groups:
         - {{ elasticsearch_group }}
-      uid:
-        lt: 1000
+      uid: 990
 group:
     {{ elasticsearch_group }}:
       exists: true
-      gid:
-        lt: 1000
+      gid: 990
 
 file:
     /opt/elasticsearch:

--- a/tasks/deb/install.yml
+++ b/tasks/deb/install.yml
@@ -15,6 +15,20 @@
     state: present
     filename: elasticsearch
 
+- name: Elasticsearch | Ensure Elasticsearch group
+  group:
+    name: "{{ elasticsearch_group }}"
+    system: true
+    gid: "{{ elasticsearch_gid | default(omit) }}"
+
+- name: Elasticsearch | Ensure Elasticsearch user
+  user:
+    name: "{{ elasticsearch_user }}"
+    group: "{{ elasticsearch_group }}"
+    shell: /bin/false
+    system: true
+    create_home: false
+    uid: "{{ elasticsearch_uid | default(omit) }}"
 - name: Elasticsearch | Install elasticsearch {{ elasticsearch_version }}
   apt:
     name: "{{ item }}={{ elasticsearch_version }}"

--- a/tasks/tar/install.yml
+++ b/tasks/tar/install.yml
@@ -13,6 +13,7 @@
   group:
     name: "{{ elasticsearch_group }}"
     system: true
+    gid: "{{ elasticsearch_gid | default(omit) }}"
 
 - name: Elasticsearch | Ensure Elasticsearch user
   user:
@@ -21,6 +22,7 @@
     shell: /bin/false
     system: true
     create_home: false
+    uid: "{{ elasticsearch_uid | default(omit) }}"
 
 - name: Elasticsearch | Check installed version
   stat:


### PR DESCRIPTION
### Description of the Change
Now you can select uid or/and gid for elasticsearch user and group to avoid problems on NFS volume with permissions. 

### Benefits

Avoid problems with permissions on NFS volume.

### Possible Drawbacks

None, if omit new parameters still works as before feature.

### Applicable Issues

#46 