### PR TITLE
#49 BUGFIX Notify restart after version update on deb install mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/elasticsearch_role/tree/develop)
 
+### Fixed
+*[49](https://github.com/idealista/elasticsearch_role/issues/49) Notify restart after version update on deb install mode* @adrian-arapiles  
+*[49](https://github.com/idealista/elasticsearch_role/issues/49) Correctly reinstall plugins after version change* @adrian-arapiles
+
 ## [2.1.0](https://github.com/idealista/elasticsearch_role/tree/2.1.0)
 [Full Changelog](https://github.com/idealista/elasticsearch_role/compare/2.0.1...2.1.0)
 ### Added 

--- a/tasks/deb/install-opendistro.yml
+++ b/tasks/deb/install-opendistro.yml
@@ -20,5 +20,5 @@
     name: "opendistroforelasticsearch={{ opendistro_version }}-1"
     update_cache: true
     state: "{{ opendistro_package_state }}"
-    force: "{{ (opendistro_version not in ansible_facts.packages[item][0].version) | ternary(True, omit) }}"
+    force: "{{ (opendistro_version not in ansible_facts.packages['opendistroforelasticsearch'][0].version | default('')) | ternary(True, omit) }}"
   notify: restart elasticsearch

--- a/tasks/deb/install-opendistro.yml
+++ b/tasks/deb/install-opendistro.yml
@@ -11,9 +11,14 @@
     state: present
     filename: elasticsearch_opendistro
 
+- name: Elasticsearch | Gather package facts
+  package_facts:
+    manager: "auto"
+
 - name: Elasticsearch | Install elasticsearch_opendistro {{ opendistro_version }}
   apt:
     name: "opendistroforelasticsearch={{ opendistro_version }}-1"
     update_cache: true
     state: "{{ opendistro_package_state }}"
+    force: "{{ (opendistro_version not in ansible_facts.packages[item][0].version) | ternary(True, omit) }}"
   notify: restart elasticsearch

--- a/tasks/deb/install.yml
+++ b/tasks/deb/install.yml
@@ -39,7 +39,7 @@
     name: "{{ item }}={{ elasticsearch_version }}"
     update_cache: true
     state: "{{ elasticsearch_package_state }}"
-    force: "{{ (elasticsearch_version not in ansible_facts.packages[item][0].version) | ternary(True, omit) }}"
+    force: "{{ (elasticsearch_version not in ansible_facts.packages[item][0].version | default('')) | ternary(True, omit) }}"
   loop:
     - "{{ (elasticsearch_license_type == 'oss') | ternary('elasticsearch-oss', 'elasticsearch') }}"
   register: elasticsearch_deb_upgraded

--- a/tasks/deb/install.yml
+++ b/tasks/deb/install.yml
@@ -29,13 +29,22 @@
     system: true
     create_home: false
     uid: "{{ elasticsearch_uid | default(omit) }}"
+
+- name: Elasticsearch | Gather package facts
+  package_facts:
+    manager: "auto"
+
 - name: Elasticsearch | Install elasticsearch {{ elasticsearch_version }}
   apt:
     name: "{{ item }}={{ elasticsearch_version }}"
     update_cache: true
     state: "{{ elasticsearch_package_state }}"
+    force: "{{ (elasticsearch_version not in ansible_facts.packages[item][0].version) | ternary(True, omit) }}"
   loop:
     - "{{ (elasticsearch_license_type == 'oss') | ternary('elasticsearch-oss', 'elasticsearch') }}"
+  register: elasticsearch_deb_upgraded
+  notify:
+    - restart elasticsearch
 
 - name: Elasticsearch | Include vars for opendistro
   include_vars: vars/opendistro.yml

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,5 +1,19 @@
 ---
 
+- name: Elasticsearch | Remove to upgrade elasticsearch plugins
+  elasticsearch_plugin:
+    name: "{{ item.name }}"
+    plugin_bin: "{{ elasticsearch_home }}/bin/elasticsearch-plugin"
+    plugin_dir: "{{ elasticsearch_home }}/plugins"
+    state: "absent"
+    force: "{{ item.force | default(omit) }}"
+  loop: "{{ elasticsearch_plugins }}"
+  become_user: "{{ elasticsearch_user }}"
+  when:
+    - elasticsearch_plugins | length > 0
+    - elasticsearch_version_check is defined and not elasticsearch_version_check.stat.exists or
+      elasticsearch_deb_upgraded is defined and elasticsearch_deb_upgraded.changed
+
 - name: Elasticsearch | Install elasticsearch plugins
   elasticsearch_plugin:
     name: "{{ item.name }}"


### PR DESCRIPTION
### Description
After upgrade version of elasticsearch installing as deb mode, the notify is missing and service isn't restarted.

### Benefits
Now elasticsearch service will restart after version change even it only installed.
Plugins correctly upgrade on change version too.

### Possible Drawbacks
None as far I know.

### Applicable Issues
#49 
