### PR TITLE
Add JVM version to jvm.options to support multiple JVM versions (Fix #52)

### DIFF
--- a/templates/tar/jvm.options.j2
+++ b/templates/tar/jvm.options.j2
@@ -38,9 +38,9 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 
 ## G1GC Configuration
 # NOTE: G1GC is only supported on JDK version 10 or later.
@@ -49,6 +49,10 @@
 # 10-:-XX:-UseCMSInitiatingOccupancyOnly
 # 10-:-XX:+UseG1GC
 # 10-:-XX:InitiatingHeapOccupancyPercent=75
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
 
 ## optimizations
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

`jvm.options` [template](https://github.com/idealista/elasticsearch_role/blob/master/templates/tar/jvm.options.j2#L41) used by default does not use [JVM options syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/advanced-configuration.html#jvm-options-syntax) to apply JVM options for each JVM version. That causes an error in #52 because it was applying to a JVM 15 the option `UseConcMarkSweepGC`, which [is no longer supported since JVM 14](https://openjdk.java.net/jeps/363).

### Benefits

Now jvm.options configuration file supports multiple JVM versions. 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

#### Side-effects
Support for new Java version. Need to add [new JDK version](https://hub.docker.com/layers/idealista/jdk/14.0.2-focal-openjdk-headless/images/sha256-7473f165ccb3a522db93dada7ec3f0c63430cbc0fb5aa1d130e80e270db266bc?context=explore) [to Travis](https://github.com/idealista/elasticsearch_role/blob/master/.travis.yml#L11) to check 

### Applicable Issues

fix #52 

redo of #53