### PR TITLE
Add recurse: yes to elasticsearch config paths.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-dist: focal
+dist: jammy
 language: python
 python: "3.9.15"
 os: linux
@@ -12,14 +12,13 @@ env:
   global:
     - PIPENV_IGNORE_VIRTUALENVS=1
   jobs:
-    - MOLECULE_DISTRO=idealista/jdk:8u292-buster-adoptopenjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64 ELASTICSEARCH_VERSION=7.17.10
-    - MOLECULE_DISTRO=idealista/jdk:11.0.14-buster-openjdk-headless JAVA_JDK_HOME=/usr/lib/jvm/java-11-openjdk-amd64 ELASTICSEARCH_VERSION=7.17.10
-    - MOLECULE_DISTRO=debian:buster-slim ELASTICSEARCH_VERSION=7.17.10
-    - MOLECULE_DISTRO=debian:buster-slim ELASTICSEARCH_VERSION=8.7.1
-    - MOLECULE_DISTRO=idealista/jdk:8u292-bullseye-adoptopenjdk-headless ELASTICSEARCH_VERSION=7.17.10
-    - MOLECULE_DISTRO=idealista/jdk:11.0.16-bullseye-openjdk-headless ELASTICSEARCH_VERSION=7.17.10
-    - MOLECULE_DISTRO=idealista/jdk:17.0.4-bullseye-openjdk-headless ELASTICSEARCH_VERSION=7.17.10
-    - MOLECULE_DISTRO=idealista/jdk:17.0.4-bullseye-openjdk-headless ELASTICSEARCH_VERSION=8.7.1
+    - MOLECULE_DISTRO=debian:buster-slim ELASTICSEARCH_VERSION=7.17.28
+    - MOLECULE_DISTRO=debian:buster-slim ELASTICSEARCH_VERSION=8.18.0
+    - MOLECULE_DISTRO=debian:buster-slim ELASTICSEARCH_VERSION=9.0.0
+    - MOLECULE_DISTRO=idealista/jdk:11.0.20-bullseye-temurin-jdk ELASTICSEARCH_VERSION=7.17.28
+    - MOLECULE_DISTRO=idealista/jdk:17.0.8-bullseye-temurin-jdk ELASTICSEARCH_VERSION=7.17.28
+    - MOLECULE_DISTRO=idealista/jdk:17.0.8-bullseye-temurin-jdk ELASTICSEARCH_VERSION=8.18.0
+    - MOLECULE_DISTRO=idealista/jdk:17.0.8-bullseye-temurin-jdk ELASTICSEARCH_VERSION=9.0.0
 script:
   - pipenv run molecule test --all
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,12 +21,13 @@ platforms:
       - /run
       - /run/lock
     volumes:
-      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/cgroup:/sys/fs/cgroup:rw'
     ulimits:
       - nofile:65535:65535
       - memlock:-1:-1
     stop_signal: 'RTMIN+3'
     command: '/lib/systemd/systemd'
+    cgroupns_mode: host
     networks:
       - name: es-network
         aliases:
@@ -46,11 +47,12 @@ platforms:
       - /run
       - /run/lock
     volumes:
-      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/cgroup:/sys/fs/cgroup:rw'
     ulimits:
       - nofile:65535:65535
       - memlock:-1:-1
     command: '/lib/systemd/systemd'
+    cgroupns_mode: host
     stop_signal: 'RTMIN+3'
     networks:
       - name: es-network
@@ -71,8 +73,9 @@ platforms:
       - /run
       - /run/lock
     volumes:
-      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/cgroup:/sys/fs/cgroup:rw'
     command: '/lib/systemd/systemd'
+    cgroupns_mode: host
     ulimits:
       - nofile:65535:65535
       - memlock:-1:-1

--- a/tasks/deb/config.yml
+++ b/tasks/deb/config.yml
@@ -7,6 +7,7 @@
     owner: "{{ elasticsearch_user }}"
     group: "{{ elasticsearch_group }}"
     mode: 0755
+    recurse: yes
   loop:
     - "{{ elasticsearch_conf_dir }}"
     - "{{ elasticsearch_log_dir }}"

--- a/tasks/tar/config.yml
+++ b/tasks/tar/config.yml
@@ -7,6 +7,7 @@
     owner: "{{ elasticsearch_user }}"
     group: "{{ elasticsearch_group }}"
     mode: 0755
+    recurse: yes
   loop:
     - "{{ elasticsearch_conf_dir }}"
     - "{{ elasticsearch_log_dir }}"


### PR DESCRIPTION
### Description of the Change

- Add `recurse: yes` on configure owner and permissions in configuration folders task. In some cases, when folders already exists the owner changes, and it makes service throws an AccessDeniedException.


### Benefits

Fix error when upgrading elasticsearch in some cases.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
